### PR TITLE
Use explicit react-router{,-dom}@5

### DIFF
--- a/src/main/resources/dashboard/index.html
+++ b/src/main/resources/dashboard/index.html
@@ -12,8 +12,8 @@
   <!-- Load React. -->
   <script src="https://unpkg.com/react@16/umd/react.production.min.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@16/umd/react-dom.production.min.js" crossorigin></script>
-  <script src="https://unpkg.com/react-router/umd/react-router.min.js" crossorigin></script>
-  <script src="https://unpkg.com/react-router-dom/umd/react-router-dom.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-router@5/umd/react-router.min.js" crossorigin></script>
+  <script src="https://unpkg.com/react-router-dom@5/umd/react-router-dom.min.js" crossorigin></script>
 
 
   <!-- Load Greenish React components. -->


### PR DESCRIPTION
Previously, the other two React CDN URLs mentioned an explicit
version, but the `react-router*` URLs did not. With their recent
upgrade to version 6, they had become incompatible (with each other or
with our code).

Explicitly requesting version 5 lets our dashboards render again.